### PR TITLE
Require the Minecraft version defined in gradle.properties.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,10 @@ processResources {
 
     from(sourceSets.main.resources.srcDirs) {
         include "fabric.mod.json"
-        expand "version": project.version
+        expand(
+            "version": project.version,
+            "minecraft_version": project.minecraft_version
+        )
     }
 
     from(sourceSets.main.resources.srcDirs) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
   "depends": {
     "fabricloader": ">=0.9.0+build.204",
     "fabric": "*",
-    "minecraft": "1.16.2"
+    "minecraft": "${minecraft_version}"
   },
   "accessWidener": "packed.accesswidener"
 }


### PR DESCRIPTION
This ensure the Minecraft version required by the jar matches the one defined in gradle.properties.