### PR TITLE
Require Java 8 instead of Java 11.

### DIFF
--- a/src/main/resources/packed.mixins.json
+++ b/src/main/resources/packed.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "de.geekeey.packed.mixin",
-  "compatibilityLevel": "JAVA_11",
+  "compatibilityLevel": "JAVA_8",
   "mixins": [
     "BarrelBlockEntityMixin",
     "ChestBlockEntityMixin"


### PR DESCRIPTION
Java 11 is required though it seems unneeded. This just changes it to Java 8, so the mod can be used with the JVM shipped with the Minecraft launcher.