### PR TITLE
Include the Minecraft version in the jar file name.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-archivesBaseName = project.archives_base_name
+archivesBaseName = project.archives_base_name + "-mc${project.minecraft_version}"
 version = project.mod_version
 group = project.maven_group
 


### PR DESCRIPTION
I am maintaining two mod sets, one for 1.16.1 and one for 1.16.2. I am always confused if I download the two versions of Packed at the same time since they have the same filename.

With this change, the file is named `packed-mc${minecraft_version}-${mod_version}.jar`.